### PR TITLE
docs: Fix a few typos

### DIFF
--- a/to-be-implemented/Elf/__init__.py
+++ b/to-be-implemented/Elf/__init__.py
@@ -825,7 +825,7 @@ class Elf32Section:
 
     def getPadSize(self, offset):
         """
-        Calculate the pad necissary for this section
+        Calculate the pad necessary for this section
         based on the file offset given as an arg
         """
         ret = 0

--- a/to-be-implemented/cobra/__init__.py
+++ b/to-be-implemented/cobra/__init__.py
@@ -105,7 +105,7 @@ def getLocalInfo():
 
 def setCallerInfo(callerinfo):
     """
-    This is necissary because of crazy python method call
+    This is necessary because of crazy python method call
     name munging for thread attributes ;)
     """
     currentThread().__cobra_caller_info = callerinfo
@@ -224,7 +224,7 @@ class CobraSocket:
 
     def sendMessage(self, mtype, objname, data):
         """
-        Send message is responsable for transmission of cobra messages,
+        Send message is responsible for transmission of cobra messages,
         and socket reconnection in the event that the send fails for network
         reasons.
         """
@@ -253,7 +253,7 @@ class CobraSocket:
     def recvMessage(self):
         """
         Returns tuple of mtype, objname, and data
-        This method is *NOT* responsable for re-connection, because there
+        This method is *NOT* responsible for re-connection, because there
         is not context on the server side for what to send on re-connect.
         Client side uses of the CobraSocket object should use cobraTransaction
         to ensure re-tranmission of the request on reception errors.

--- a/to-be-implemented/vstruct/__init__.py
+++ b/to-be-implemented/vstruct/__init__.py
@@ -143,9 +143,9 @@ class VStruct(object):
     The base vstruct object.  This object may be extended *mostly*
     by setting the class-local value _fields_.  Once fields are setup
     you may use a vstruct derived class to parse out byte sequences
-    into programatically accessable fields which dereferenceable
+    into programatically accessible fields which dereferenceable
     from the instantiated structure object.  Support will probably
-    be eventually implemented for writting to those same values
+    be eventually implemented for writing to those same values
     and zipping it back up into a byte sequence.
     """
     _fields_ = ()

--- a/to-be-implemented/vstruct/win32.py
+++ b/to-be-implemented/vstruct/win32.py
@@ -72,7 +72,7 @@ class TEB(VStruct):
         #FIXME not done!
     ]
 
-# Some necissary arrays for the PEB
+# Some necessary arrays for the PEB
 class TlsExpansionBitsArray(VArray):
     _field_type_ = v_uint32
     _field_count_ = 32

--- a/to-be-implemented/vtrace/__init__.py
+++ b/to-be-implemented/vtrace/__init__.py
@@ -5,7 +5,7 @@ Vtrace is a *mostly* native python debugging framework which
 can be used to quickly write programatic debuggers and research
 tools.
 
-I'm not known for writting great docs...  but the code should
+I'm not known for writing great docs...  but the code should
 be pretty straight forward...
 
 This has been in use for over 2 years privately, but is nowhere
@@ -156,7 +156,7 @@ class Trace(Notifier):
 
 		self.initMode("RunForever", False, "Run until RunForever = False")
 		self.initMode("NonBlocking", False, "A call to wait() fires a thread to wait *for* you")
-		self.initMode("ThreadProxy", True, "Proxy necissary requests through a single thread (can deadlock...)")
+		self.initMode("ThreadProxy", True, "Proxy necessary requests through a single thread (can deadlock...)")
 		self.initMode("FastBreak", False, "Do *NOT* add/remove breakpoints per-run, but leave them there once active")
 		self.initMode("SingleStep", False, "All calls to run() actually just step.  This allows RunForever + SingleStep to step forever ;)")
 		self.initMode("FastStep", False, "All stepi() will NOT generate a step event")
@@ -300,7 +300,7 @@ class Trace(Notifier):
 		"normalized" library names.  This method returns
 		the list of normalized names for the loaded libraries.
 
-		(probably only useful for writting symbol browsers...)
+		(probably only useful for writing symbol browsers...)
 		"""
 		return self.resbynorm.keys()
 
@@ -497,7 +497,7 @@ class Trace(Notifier):
 
 	def hasMeta(self, name):
 		"""
-		Check to see if a metadata key exists... Mostly un-necissary
+		Check to see if a metadata key exists... Mostly un-necessary
 		as getMeta() with a default will set the key to the default
 		if non-existant.
 		"""
@@ -661,7 +661,7 @@ class Trace(Notifier):
 		"""
 		Because breakpoints are potentially on the remote debugger
 		and code is not pickleable in python, special access methods
-		which takes strings of python code are necissary for the
+		which takes strings of python code are necessary for the
 		vdb interface to quick script breakpoint code.  Use this method
 		to set the python code for this breakpoint.
 		"""
@@ -1250,7 +1250,7 @@ class VtraceExpression:
 		Mapped in by name
 
 	* Symbol Resolvers 
-		They are accessable by the "normalized libname" so, kernel32.dll is "kernel32"
+		They are accessible by the "normalized libname" so, kernel32.dll is "kernel32"
 		and /usr/lib/libpthread-2.0.40.so is "libpthread".  These resolvers may be
 		dereferenced to get symbols by name.  For example the expression "kernel32.CloseHandle"
 		will return the address of the CloseHandle symbol from kernel32

--- a/to-be-implemented/vtrace/notifiers.py
+++ b/to-be-implemented/vtrace/notifiers.py
@@ -3,7 +3,7 @@ Vtrace notitifers base classes and examples
 
 Vtrace supports the idea of callback notifiers which
 get called whenever particular events occur in the target
-process.  Notifiers may be registered to recieve a callback
+process.  Notifiers may be registered to receive a callback
 on any of the vtrace.NOTIFY_FOO events from vtrace.  One notifier
 *may* be registered with more than one trace, as the "notify"
 method is passed a reference to the trace for which an event
@@ -25,7 +25,7 @@ class Notifier(object):
     def __init__(self):
         """
         All extenders *must* call this.  Mostly because all the
-        goop necissary for the remote debugging stuff...
+        goop necessary for the remote debugging stuff...
         (if notifier is instantiated on server, all is well, if it's
         on the client it needs a proxy...)
         """

--- a/to-be-implemented/vtrace/platforms/base.py
+++ b/to-be-implemented/vtrace/platforms/base.py
@@ -566,14 +566,14 @@ class UtilMixin:
         """
         Initialize a mode, this should ONLY be called
         during setup routines for the trace!  It determines
-        the available mode setings.
+        the available mode settings.
         """
         self.modes[name] = bool(value)
         self.modedocs[name] = descr
 
     def release(self):
         """
-        Do cleanup when we're done.  This is mostly necissary
+        Do cleanup when we're done.  This is mostly necessary
         because of the thread proxy holding a reference to this
         tracer...  We need to let him die off and try to get
         garbage collected.
@@ -759,7 +759,7 @@ class UtilMixin:
         """
         This should be used *at load time* to setup the library
         event metadata.  This will also instantiate a VSymbolResolver
-        for this platform and setup the internal structures as necissary
+        for this platform and setup the internal structures as necessary
 
         This returns True/False for whether or not the library is
         going to be parsed (False on duplicate or non-file).

--- a/to-be-implemented/vtrace/platforms/linux.py
+++ b/to-be-implemented/vtrace/platforms/linux.py
@@ -92,7 +92,7 @@ class LinuxMixin:
 
     def setupMemFile(self, offset):
         """
-        A utility to open (if necissary) and seek the memfile
+        A utility to open (if necessary) and seek the memfile
         """
         if self.memfd == None:
             self.memfd = libc.open("/proc/%d/mem" % self.pid, O_RDWR | O_LARGEFILE, 0755)

--- a/to-be-implemented/vtrace/rmi.py
+++ b/to-be-implemented/vtrace/rmi.py
@@ -61,7 +61,7 @@ def getCallbackProxy(trace, notifier):
 
 def getCallbackPort():
     """
-    If necissary, start a callback daemon.  Return the
+    If necessary, start a callback daemon.  Return the
     ephemeral port it was bound on.
     """
     global callback_daemon

--- a/to-be-implemented/vtrace/symbase.py
+++ b/to-be-implemented/vtrace/symbase.py
@@ -59,8 +59,8 @@ class VSymbolResolver:
     def __init__(self, filename, loadbase=0, casesens=True):
         """
         The constructor for SymbolResolver and it's inheritors
-        is responsible for either parsing or settting up the
-        necissary context to parse when requested.
+        is responsible for either parsing or setting up the
+        necessary context to parse when requested.
         """
         self.loaded = False
         self.loadbase = loadbase


### PR DESCRIPTION
There are small typos in:
- to-be-implemented/Elf/__init__.py
- to-be-implemented/cobra/__init__.py
- to-be-implemented/vstruct/__init__.py
- to-be-implemented/vstruct/win32.py
- to-be-implemented/vtrace/__init__.py
- to-be-implemented/vtrace/notifiers.py
- to-be-implemented/vtrace/platforms/base.py
- to-be-implemented/vtrace/platforms/linux.py
- to-be-implemented/vtrace/rmi.py
- to-be-implemented/vtrace/symbase.py

Fixes:
- Should read `necessary` rather than `necissary`.
- Should read `writing` rather than `writting`.
- Should read `responsible` rather than `responsable`.
- Should read `accessible` rather than `accessable`.
- Should read `settings` rather than `setings`.
- Should read `setting` rather than `settting`.
- Should read `receive` rather than `recieve`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md